### PR TITLE
Add login by email instead of username.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 common/connect_database.php
+common/connect_database.php.live
 common/email_credentials.php
 logs/*.log
 uploads/*

--- a/pages/login.html
+++ b/pages/login.html
@@ -1,10 +1,14 @@
 <div class="form-group">
-    <label for="username">username:</label><br>
+    <label for="username">username or email:</label><br>
     <input type="text" class="form-control" id="username" ng-model="lc.username">
     <label for="password">password:</label><br>
     <input type="password" class="form-control" id="password" ng-model="lc.password">
     <br>
-    <a href="" class="forgot-password">forgot my password</a>
+    <button class="forgot-password" class="btn btn-default" ng-click="lc.passwordForgotten=!lc.passwordForgotten">forgot my password</button>
+    <div class="alert alert-danger alert-dismissible fade in" ng-show="lc.passwordForgotten">
+        automated password recovery is not yet available, please email to<br>
+        <a href="mailto:doubledateoc.moderator@gamail.com">DoubleDateOC.moderator@gmail.com</a>
+        to recover your password.</div>
     <div class="alert alert-danger alert-dismissible fade in" ng-show="lc.invalidParams">
         please provide a username and password</div>
     <div class="alert alert-danger alert-dismissible fade in" ng-show="lc.loginFailed">

--- a/routing.js
+++ b/routing.js
@@ -766,6 +766,7 @@ app.controller('loginController', function($location, userService){
     this.password = '';
     this.invalidParams = false;
     this.loginFailed = false;
+    this.passwordForgotten = false;
 
     // Note that the login has two parts for a normal user: log in the user, and get the profile.
     this.doLogin = function() {

--- a/user/login.php
+++ b/user/login.php
@@ -12,12 +12,13 @@ $response = [];
 // If username and password provided, try to look up the username in the user database.
 if ($username && $password) {
     if ($conn) {
-        $query = "SELECT * FROM `users` WHERE `username` = '$username' AND `locked` = '0';";
+        $query = "SELECT * FROM `users`
+                  WHERE (`username` = '$username' OR `email` = '$username') AND `locked` = '0';";
         $result = mysqli_query($conn, $query);
         if ($result && (mysqli_num_rows($result) == 1) && ($userRecord = mysqli_fetch_assoc($result))) {
-            // Got the row data.
-            if ($userRecord['username'] == $username &&
-                $userRecord['password'] == $password) {
+            // Got the row data; could have found this by username or email, so get the username from the record.
+            $username = $userRecord['username'];
+            if ($userRecord['password'] == $password) {
                 // Log this to the error_log.
                 dd_error_log("user '$username' logged in");
 

--- a/user_service.js
+++ b/user_service.js
@@ -151,12 +151,13 @@ app.service("userService", ['$http', '$q', '$log', 'profileService', function($h
                 $log.log('login: success: ' + response.success);
                 if (response.success) {
                     self.userStatus.loggedIn = true;
-                    self.userStatus.username = response.username;
+                    self.userStatus.username = username = response.username;
                     self.userStatus.name = response.name;
                     self.userStatus.userId = response.userId;
                     self.userStatus.userLevel = response.userLevel;
 
                     // Now that we have the user logged in, if this is a normal user, get the profile.
+                    // Note that we might have logged in by email, so use the returned username.
                     if (response.userLevel === 'normal') {
                         profileService.get(username)
                             .then(function(response2) {


### PR DESCRIPTION
-This will allow login by email or by username. It will only work if there is a single record with that email, so if someone puts in the same email twice, it will keep you from logging in.
- Also changed the label from "username:" to "username or email:".
- Also added a pop-up when you click on "Forgot password" that tells you to email the moderator.